### PR TITLE
Evaluate incoming lines to determine indentation width

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -148,7 +148,8 @@ class NetworkModule(AnsibleModule):
         provider = params.get('provider') or dict()
         for key, value in provider.items():
             if key in NET_COMMON_ARGS.keys():
-                params[key] = value
+                if not params.get(key) and value is not None:
+                    params[key] = value
         return params
 
     def connect(self):

--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -66,9 +66,9 @@ def parse(lines, indent):
             line_indent = match.start(1)
 
             if not first_child:
-                # let the template dictate spacing.
+                # let the first child occurrence determine indentation width.
+                first_child = True
                 if line_indent > 0:
-                    first_child = True
                     indent = line_indent
 
             if line_indent % indent > 0:

--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -39,47 +39,58 @@ class ConfigLine(object):
         return not self.__eq__(other)
 
 def parse(lines, indent):
-        toplevel = re.compile(r'\S')
-        childline = re.compile(r'^\s*(.+)$')
-        repl = r'([{|}|;])'
+    toplevel = re.compile(r'\S')
+    childline = re.compile(r'^\s*(.+)$')
+    repl = r'([{|}|;])'
 
-        ancestors = list()
-        config = list()
+    ancestors = list()
+    config = list()
+    first_child = False
 
-        for line in str(lines).split('\n'):
-            text = str(re.sub(repl, '', line)).strip()
+    for line in str(lines).split('\n'):
+        text = str(re.sub(repl, '', line)).strip()
 
-            cfg = ConfigLine(text)
-            cfg.raw = line
+        cfg = ConfigLine(text)
+        cfg.raw = line
 
-            if not text or text[0] in ['!', '#']:
+        if not text or text[0] in ['!', '#']:
+            continue
+
+        # handle top level commands
+        if toplevel.match(line):
+            ancestors = [cfg]
+
+        # handle sub level commands
+        else:
+            match = childline.match(line)
+            line_indent = match.start(1)
+
+            if not first_child:
+                # let the template dictate spacing.
+                if line_indent > 0:
+                    first_child = True
+                    indent = line_indent
+
+            if line_indent % indent > 0:
+                raise Exception("Expected indentation to be a multiple of {0:d}.".format(indent))
+
+            level = int(line_indent / indent)
+            parent_level = level - 1
+
+            cfg.parents = ancestors[:level]
+
+            if level > len(ancestors):
+                config.append(cfg)
                 continue
 
-            # handle top level commands
-            if toplevel.match(line):
-                ancestors = [cfg]
+            for i in range(level, len(ancestors)):
+                ancestors.pop()
 
-            # handle sub level commands
-            else:
-                match = childline.match(line)
-                line_indent = match.start(1)
-                level = int(line_indent / indent)
-                parent_level = level - 1
+            ancestors.append(cfg)
+            ancestors[parent_level].children.append(cfg)
 
-                cfg.parents = ancestors[:level]
+        config.append(cfg)
 
-                if level > len(ancestors):
-                    config.append(cfg)
-                    continue
-
-                for i in range(level, len(ancestors)):
-                    ancestors.pop()
-
-                ancestors.append(cfg)
-                ancestors[parent_level].children.append(cfg)
-
-            config.append(cfg)
-
-        return config
+    return config
 
 

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -194,7 +194,11 @@ class NetworkModule(AnsibleModule):
         self.connection.close()
 
     def parse_config(self, cfg):
-        return parse(cfg, indent=2)
+        try:
+            result = parse(cfg, indent=2)
+            return result
+        except Exception:
+            raise
 
     def get_config(self):
         cmd = 'show running-config'

--- a/lib/ansible/plugins/action/eos_config.py
+++ b/lib/ansible/plugins/action/eos_config.py
@@ -1,0 +1,26 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass

--- a/lib/ansible/plugins/action/ios_config.py
+++ b/lib/ansible/plugins/action/ios_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+

--- a/lib/ansible/plugins/action/iosxr_config.py
+++ b/lib/ansible/plugins/action/iosxr_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+

--- a/lib/ansible/plugins/action/junos_config.py
+++ b/lib/ansible/plugins/action/junos_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    NET_PROVIDER = 'junos'
+
+

--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -1,0 +1,90 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import os
+import time
+import glob
+import urlparse
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.boolean import boolean
+from ansible.utils.unicode import to_unicode
+
+BOOLEANS = ('true', 'false', 'yes', 'no')
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['changed'] = False
+
+        self._handle_template()
+
+        result.update(self._execute_module(module_name=self._task.action,
+            module_args=self._task.args, task_vars=task_vars))
+
+        if self._task.args.get('backup'):
+            self._write_backup(task_vars['inventory_hostname'], result['_backup'])
+
+        if '_backup' in result:
+            del result['_backup']
+
+        return result
+
+    def _write_backup(self, host, contents):
+        if not os.path.exists('backup'):
+            os.mkdir('backup')
+        for fn in glob.glob('backup/%s*' % host):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = 'backup/%s_config.%s' % (host, tstamp)
+        open(filename, 'w').write(contents)
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+
+        if os.path.isabs(src) or urlparse.urlsplit('src').scheme:
+            source = src
+
+        elif self._task._role is not None:
+            source = self._loader.path_dwim_relative(self._task._role._role_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(self._task._role._role_path, src)
+        else:
+            source = self._loader.path_dwim_relative(self._loader.get_basedir(), 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(self._loader.get_basedir(), src)
+
+        if not os.path.exists(source):
+            return
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_unicode(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        self._task.args['src'] = self._templar.template(template_data)
+
+

--- a/lib/ansible/plugins/action/nxos_config.py
+++ b/lib/ansible/plugins/action/nxos_config.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+
+    def _map_keys(self, task_vars, args):
+        args['port'] = (task_vars.get('ansible_nxapi_port') or 0)
+        args['username'] = task_vars.get('ansible_nxapi_user')
+        args['password'] = task_vars.get('ansible_nxapi_pass')
+        args['protocol'] = task_vars.get('ansible_nxapi_proto')

--- a/lib/ansible/plugins/action/nxos_config.py
+++ b/lib/ansible/plugins/action/nxos_config.py
@@ -23,9 +23,5 @@ from ansible.plugins.action import ActionBase
 from ansible.plugins.action.net_config import ActionModule as NetActionModule
 
 class ActionModule(NetActionModule, ActionBase):
+    pass
 
-    def _map_keys(self, task_vars, args):
-        args['port'] = (task_vars.get('ansible_nxapi_port') or 0)
-        args['username'] = task_vars.get('ansible_nxapi_user')
-        args['password'] = task_vars.get('ansible_nxapi_pass')
-        args['protocol'] = task_vars.get('ansible_nxapi_proto')

--- a/lib/ansible/plugins/action/ops_config.py
+++ b/lib/ansible/plugins/action/ops_config.py
@@ -47,9 +47,4 @@ class ActionModule(NetActionModule, ActionBase):
 
         return result
 
-    def _map_keys(self, task_vars, args):
-        args['port'] = (task_vars.get('ansible_rest_port') or 0)
-        args['username'] = task_vars.get('ansible_rest_user')
-        args['password'] = task_vars.get('ansible_rest_pass')
-        args['protocol'] = task_vars.get('ansible_rest_proto')
 

--- a/lib/ansible/plugins/action/ops_config.py
+++ b/lib/ansible/plugins/action/ops_config.py
@@ -1,0 +1,55 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        if self._connection.transport == 'local':
+            return super(ActionModule, self).run(tmp, task_vars)
+
+        result = dict(changed=False)
+
+        if isinstance(self._task.args['src'], basestring):
+            self._handle_template()
+
+        self._task.args['config'] = task_vars.get('config')
+
+        result.update(self._execute_module(module_name=self._task.action,
+            module_args=self._task.args, task_vars=task_vars))
+
+        if self._task.args.get('backup') and '_config' in result:
+            contents = json.dumps(result['_config'], indent=4)
+            self._write_backup(task_vars['inventory_hostname'], contents)
+            del result['_config']
+
+        return result
+
+    def _map_keys(self, task_vars, args):
+        args['port'] = (task_vars.get('ansible_rest_port') or 0)
+        args['username'] = task_vars.get('ansible_rest_user')
+        args['password'] = task_vars.get('ansible_rest_pass')
+        args['protocol'] = task_vars.get('ansible_rest_proto')
+


### PR DESCRIPTION
Determine the indentation width by evaluating the first child. Let the indentation width be X. All subsequent children should have an indentation width that is a multiple of X. If the indentation width is not a multiple of X, raise an error. The error is raised to the outermost module, allowing it to wrap the error with the name of the object being parsed. In general the thing being parsed will be the config src.

Fixed the spacing in parser definition. For some reason the body of parser was indented by 8 spaces rather than 4.
